### PR TITLE
Make slicing as lazy as currently feasible

### DIFF
--- a/listish.py
+++ b/listish.py
@@ -9,6 +9,31 @@ from collections import Sequence, MutableSequence
 __version__ = '0.1'
 
 
+class MustExhaustException(RuntimeError):
+    """
+    Raised when a slice cannot be converted into a list of indexes as it requires knowledge of the length of the
+    iterable
+    """
+
+
+def slice_to_indicies(slice_):
+    unbounded_end = slice_.start is not None and slice_.stop is None
+    unbounded_step = (
+        slice_.start is None and
+        slice_.stop is None and
+        slice_.step is not None
+    )
+    negative_index = (
+        (slice_.start is not None and slice_.start < 0) or
+        (slice_.stop is not None and slice_.stop < 0)
+    )
+
+    if unbounded_end or unbounded_step or negative_index:
+        raise MustExhaustException()
+
+    return slice_.indicies(max(slice_.stop))
+
+
 class Tupleish(Sequence):
     """
     A lazily evaluated tuple-like object.
@@ -28,23 +53,49 @@ class Tupleish(Sequence):
         for value in self._datastore:
             yield value
         while True:
-            # _consume_next will alread raise StopIteration when it is
+            # _consume_next will already raise StopIteration when it is
             # exhausted
             yield self._consume_next()
 
     def __getitem__(self, index):
         if isinstance(index, slice):
-            return [
-                self[i]
-                for i
-                in range(*index.indices(len(self)))
-                ]
+            return list(self._get_items_in_bounds(
+                range(*self._get_indices(index))))
         try:
             while len(self._datastore) < index + 1:
                 self._consume_next()
             return self._datastore[index]
         except StopIteration:
             raise IndexError("index out of range")
+
+    def _get_items_in_bounds(self, indexes):
+        for i in indexes:
+            try:
+                yield self[i]
+            except IndexError:
+                pass
+
+    def _get_indices(self, slice_):
+        try:
+            unbounded_end = slice_.start is not None and slice_.stop is None
+            unbounded_step = (
+                slice_.start is None and
+                slice_.stop is None and
+                slice_.step is not None
+            )
+            negative_index = (
+                (slice_.start is not None and slice_.start < 0) or
+                (slice_.stop is not None and slice_.stop < 0)
+            )
+
+            if unbounded_end or unbounded_step or negative_index:
+                raise MustExhaustException()
+
+            length = slice_.stop + 1
+        except MustExhaustException:
+            length = len(self)
+
+        return slice_.indices(length)
 
     def __len__(self):
         self._datastore += list(self._iterator)

--- a/listish.py
+++ b/listish.py
@@ -4,6 +4,11 @@ wrap any iterator.
 """
 
 from collections import Sequence, MutableSequence
+from sys import version_info
+
+
+if version_info < (3, 0):  # pragma: no cover
+    range = xrange  # pylint: disable=redefined-builtin,invalid-name
 
 
 __version__ = '0.1'

--- a/listish.py
+++ b/listish.py
@@ -16,24 +16,6 @@ class MustExhaustException(RuntimeError):
     """
 
 
-def slice_to_indicies(slice_):
-    unbounded_end = slice_.start is not None and slice_.stop is None
-    unbounded_step = (
-        slice_.start is None and
-        slice_.stop is None and
-        slice_.step is not None
-    )
-    negative_index = (
-        (slice_.start is not None and slice_.start < 0) or
-        (slice_.stop is not None and slice_.stop < 0)
-    )
-
-    if unbounded_end or unbounded_step or negative_index:
-        raise MustExhaustException()
-
-    return slice_.indicies(max(slice_.stop))
-
-
 class Tupleish(Sequence):
     """
     A lazily evaluated tuple-like object.

--- a/listish.py
+++ b/listish.py
@@ -11,8 +11,8 @@ __version__ = '0.1'
 
 class MustExhaustException(RuntimeError):
     """
-    Raised when a slice cannot be converted into a list of indexes as it requires knowledge of the length of the
-    iterable
+    Raised when a slice cannot be converted into a list of indexes as it
+    requires knowledge of the length of the iterable
     """
 
 

--- a/tests/test_listish.py
+++ b/tests/test_listish.py
@@ -202,6 +202,31 @@ def test_add_slice(li, ins):
     assert list(lst) == list(lc)
 
 
+@given(
+    li=list_and_index(index_count=2),
+    step=strategies.one_of(
+        strategies.integers(min_value=1),
+        strategies.integers(max_value=-1)
+    ),
+    data=strategies.data()
+)
+def test_replace_extended_slice(li, step, data):
+    l, i, j = li
+    lst = Listish(l)
+
+    replacement_length = len(l[i:j:step])
+    replacement = data.draw(strategies.lists(
+        strategies.integers(),
+        min_size=replacement_length,
+        max_size=replacement_length
+    ))
+
+    l[i:j:step] = replacement
+    lst[i:j:step] = replacement
+
+    assert l == list(lst)
+
+
 @given(li=list_and_index(index_count=2))
 def test_del_slice(li):
     l, i, j = li
@@ -214,3 +239,21 @@ def test_del_slice(li):
     assert len(lst) == len(lc)
 
     assert list(lst) == list(lc)
+
+
+@given(
+    li=list_and_index(index_count=2),
+    step=strategies.one_of(
+        strategies.integers(min_value=1),
+        strategies.integers(max_value=-1)
+    ),
+)
+def test_delete_extended_slice(li, step):
+    l, i, j = li
+    lc = copy(l)
+    lst = Listish(l)
+
+    del lc[i:j:step]
+    del lst[i:j:step]
+
+    assert lc == list(lst)

--- a/tests/test_listish.py
+++ b/tests/test_listish.py
@@ -168,10 +168,7 @@ def test_get_slice(cls, li):
 def test_get_potentially_out_of_bounds_slice(cls, l, start, end):
     lst = cls(l)
 
-    for k, l in zip(
-            l[start:end],
-            lst[start:end]):
-        assert k is l
+    assert l[start:end] == lst[start:end]
 
 
 @pytest.mark.parametrize('cls', [Tupleish, Listish])
@@ -186,10 +183,7 @@ def test_get_extended_slice(cls, li, step):
     l, i, j = li
     lst = cls(l)
 
-    for k, l in zip(
-            l[i:j:step],
-            lst[i:j:step]):
-        assert k is l
+    assert l[i:j:step] == lst[i:j:step]
 
 
 @given(
@@ -205,10 +199,7 @@ def test_add_slice(li, ins):
     lc[i:j] = ins
     lst[i:j] = ins
 
-    assert len(lst) == len(lc)
-
-    for m, n in zip(lst, lc):
-        assert m == n
+    assert list(lst) == list(lc)
 
 
 @given(li=list_and_index(index_count=2))
@@ -222,5 +213,4 @@ def test_del_slice(li):
 
     assert len(lst) == len(lc)
 
-    for m, n in zip(lst, lc):
-        assert m == n
+    assert list(lst) == list(lc)

--- a/tests/test_listish.py
+++ b/tests/test_listish.py
@@ -2,7 +2,7 @@
 
 import random
 from copy import copy
-from sys import maxsize
+from sys import maxsize, version_info
 
 import pytest
 from hypothesis import given, strategies
@@ -159,11 +159,14 @@ def test_get_slice(cls, li):
         assert k is l
 
 
+max_index_size = maxsize - 2 if version_info < (3, 4) else None
+
+
 @pytest.mark.parametrize('cls', [Tupleish, Listish])
 @given(
     l=strategies.lists(strategies.integers()),
-    start=strategies.integers(),
-    end=strategies.integers(),
+    start=strategies.integers(max_value=max_index_size),
+    end=strategies.integers(max_value=max_index_size),
 )
 def test_get_potentially_out_of_bounds_slice(cls, l, start, end):
     lst = cls(l)

--- a/tests/test_listish.py
+++ b/tests/test_listish.py
@@ -159,10 +159,43 @@ def test_get_slice(cls, li):
         assert k is l
 
 
+@pytest.mark.parametrize('cls', [Tupleish, Listish])
+@given(
+    l=strategies.lists(strategies.integers()),
+    start=strategies.integers(),
+    end=strategies.integers(),
+)
+def test_get_potentially_out_of_bounds_slice(cls, l, start, end):
+    lst = cls(l)
+
+    for k, l in zip(
+            l[start:end],
+            lst[start:end]):
+        assert k is l
+
+
+@pytest.mark.parametrize('cls', [Tupleish, Listish])
+@given(
+    li=list_and_index(index_count=2),
+    step=strategies.one_of(
+        strategies.integers(min_value=1),
+        strategies.integers(max_value=-1)
+    ),
+)
+def test_get_extended_slice(cls, li, step):
+    l, i, j = li
+    lst = cls(l)
+
+    for k, l in zip(
+            l[i:j:step],
+            lst[i:j:step]):
+        assert k is l
+
+
 @given(
     li=list_and_index(index_count=2),
     ins=strategies.lists(strategies.integers()),
-    )
+)
 def test_add_slice(li, ins):
     l, i, j = li
     lc = copy(l)


### PR DESCRIPTION
This PR adds support for lazy extended slicing by identifying slices that have a known length without knowing the length of the iterable they are slicing against and allowing for retrieval, mutation and deletion of those slices, as per the rules of python slicing, without exhausting the full length of the iterator where possible.